### PR TITLE
Add a validation rule for content_type pin.image

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'coffee-rails', '~> 4.2'
 gem 'jquery-rails'# Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.5'
-gem 'bootstrap-sass'
+gem 'bootstrap-sass', '~> 3.2.0'
 gem 'devise'
 gem 'paperclip', '~> 4.2'
 

--- a/app/models/pin.rb
+++ b/app/models/pin.rb
@@ -1,4 +1,5 @@
 class Pin < ActiveRecord::Base
      belongs_to :user
      has_attached_file :image, :styles => { :medium => "300x300>", :thumb => "100x100>" }
+     validates_attachment_content_type :image, :content_type => ["image/jpg", "image/jpeg", "image/png", "image/gif"]
 end

--- a/app/views/pins/show.html.erb
+++ b/app/views/pins/show.html.erb
@@ -1,6 +1,7 @@
 <p id="notice"><%= notice %></p>
 
 <p>
+  <%= link_to image_tag(@pin.image.url, class: 'media-object'), @pin.image.url, target: '_blank' %>
   <strong>Description:</strong>
   <%= @pin.description %>
 </p>


### PR DESCRIPTION
- Paperclip 4.0 requires a validation rule for file attachments
- Set this to accept common image types (jpg, png, gif)